### PR TITLE
Automatic logoff of non-admin users and redirection to login page.

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,7 +2,7 @@
 de:
   maintenance_mode_active: Wartungsmodus aktivieren?
   maintenance_mode_message_label: Wartungshinweis
-  maintenance_mode_message_default: "<h1>Geplante Wartungsarbeiten</h1>\n<p>Redmine ist für kurze Zeit nicht verfügbar, um eine regelmäßige Instandhaltung durchzuführen. Prüfe in einigen Minuten erneut.</p>"
+  maintenance_mode_message_default: "Redmine ist für kurze Zeit nicht verfügbar, um eine regelmäßige Instandhaltung durchzuführen. Prüfe in einigen Minuten erneut!"
   maintenance_mode_admin_message: "System befindet sich im Wartungsmodus! Nur Administratoren haben Zugriff! Der Wartungsmodus kann auf <a href=\"%{pluginurl}\">dieser Seite</a> beendet werden."
   maintenance_mode_schedule_directions: Möchten Sie Wartungsarbeiten planen und die Nutzer vorab per Banner benachrichtigen?
   maintenance_mode_schedule_label: Wartungsarbeiten planen?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   maintenance_mode_active: Activate maintenance mode?
   maintenance_mode_message_label: Maintenance message
-  maintenance_mode_message_default: "<h1>Ongoing maintenance</h1>\n<p>This site is currently under maintenance. Please check back later.</p>"
+  maintenance_mode_message_default: "This site is currently under maintenance. Please check back later!"
   maintenance_mode_admin_message: "System is in maintenance mode! Only administrators have access. Maintenance mode can be disabled on <a href=\"%{pluginurl}\">this site</a>."
   maintenance_mode_schedule_directions: Do you want to schedule maintenance work and notify users in advance?
   maintenance_mode_schedule_label: Schedule maintenance?

--- a/lib/maintenance_mode.rb
+++ b/lib/maintenance_mode.rb
@@ -4,25 +4,26 @@ module MaintenanceMode
   def self.included(base)
     base.class_eval do
       unloadable
-  	  
+          
       # show maintenance message for all "normal" users (except admins)
       def show_maintenance_mode_page
-	    
+            
         # read plugin settings
-		settings = MaintenanceModeFunctions.get_maintenance_plugin_settings
-		
-		# only activate maintenance message if maintenance mode is activated or if we're in the middle of a scheduled maintenance 
+        settings = MaintenanceModeFunctions.get_maintenance_plugin_settings
+                
+        # only activate maintenance message if maintenance mode is activated or if we're in the middle of a scheduled maintenance 
         if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance
-		  # and only activate it for non-admin users
-		  unless User.current.admin?
-            render :text => settings.has_key?(:maintenance_message_f) ? settings[:maintenance_message_f] : settings[:maintenance_message]
+          # and only activate it for non-admin users
+          unless User.current.admin? || !User.current.logged?
+            logout_user
+            require_login 
             return false
-		  end
-		end
+          end
+        end
       end
-	  
+          
       before_filter(:show_maintenance_mode_page)
-	  
+
     end
   end
 end

--- a/lib/maintenance_mode_hooks.rb
+++ b/lib/maintenance_mode_hooks.rb
@@ -3,41 +3,46 @@ class MaintenanceModeHook < Redmine::Hook::ViewListener
   
   # add css and javascript if we're in the middle of a maintenance
   def view_layouts_base_html_head(context = {})
-  	# read plugin settings
-  	settings = MaintenanceModeFunctions.get_maintenance_plugin_settings
-  	
-	if settings[:maintenance_active] || settings[:maintenance_scheduled] || MaintenanceModeFunctions.is_now_scheduled_maintenance
-	  tags = stylesheet_link_tag 'maintenance_mode', :plugin => 'redmine_maintenance_mode'
-	  tags += javascript_include_tag 'banner.js', :plugin => 'redmine_maintenance_mode'
-	  return tags
-	end
+    # read plugin settings
+    settings = MaintenanceModeFunctions.get_maintenance_plugin_settings
+        
+    if settings[:maintenance_active] || settings[:maintenance_scheduled] || MaintenanceModeFunctions.is_now_scheduled_maintenance
+      tags = stylesheet_link_tag 'maintenance_mode', :plugin => 'redmine_maintenance_mode'
+      tags += javascript_include_tag 'banner.js', :plugin => 'redmine_maintenance_mode'
+      return tags
+    end
   end
   
   
   # put admin message at the body_bottom as there is no body_top (#17454)
   # a javascript function will then bring it up to the top
   def view_layouts_base_body_bottom(context = {})
-  	
-  	# read plugin settings
-  	settings = MaintenanceModeFunctions.get_maintenance_plugin_settings
-  	
-	# only show banner for logged in users
-	if User.current.login?
-	  
-	  # if maintenance mode is activated or if we are in the middle of a scheduled maintenance
-	  if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance
-	    plugin_url = Setting.protocol + "://" + Setting.host_name + Redmine::Utils.relative_url_root + "/settings/plugin/redmine_maintenance_mode"
-		div_banner l(:maintenance_mode_admin_message) % [ :pluginurl => plugin_url ]
-	  
-	  # if maintenance is scheduled and current time is before the scheduled maintenance start time
-	  elsif settings[:maintenance_scheduled] && settings.has_key?(:schedule_start) && Time.now < Time.parse(settings[:schedule_start])
-		div_banner settings[:scheduled_message_f]
-	  end
-	  
-	end
+        
+    # read plugin settings
+    settings = MaintenanceModeFunctions.get_maintenance_plugin_settings
+        
+    # only show banner for logged in users
+    if User.current.login?
+          
+      # if maintenance mode is activated or if we are in the middle of a scheduled maintenance
+      if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance
+        plugin_url = Setting.protocol + "://" + Setting.host_name + "/settings/plugin/redmine_maintenance_mode"
+        div_banner l(:maintenance_mode_admin_message) % [ :pluginurl => plugin_url ]
+          
+        # if maintenance is scheduled and current time is before the scheduled maintenance start time
+      elsif settings[:maintenance_scheduled] && settings.has_key?(:schedule_start) && Time.now < Time.parse(settings[:schedule_start])
+        div_banner settings[:scheduled_message_f]
+      end
+     
+    else
+
+      if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance
+        div_banner settings[:maintenance_message_f]
+      end
+
+    end
   end
-  
-  
+    
   # html code for the banner notification with custom message
   def div_banner(message)
     "<div id=\"maintenance_mode_banner\">" + message + "</div>"


### PR DESCRIPTION
Non-admin users are automatically logged out when the system is under maintenance, and redirected
to the login screen. In the login screen a banner is shown on the top displaying the maintenance
message set by the administrator. This way, admin users can log in even under maintenance.

BTW, fixes issue #2 and the maintenance mode user experience for non-admins is a bit better.
