### PR TITLE
use 'deface' gem/plugin for views + additional v2.0 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ $ rake redmine:plugins:migrate RAILS_ENV=production
 * Restart redmine
 
 
+Upgrade from plugin version 1.x
+-------------------------------
+
+* change to the plugin directory in `redmine_root/plugins/redmine_maintenance_mode`
+* update the git repository by running
+```
+$ git pull
+```
+* change back to the plugins directory `redmine_root/plugins/`
+* Install the ["Redmine Base Deface"](https://github.com/jbbarth/redmine_base_deface)-Plugin
+  * it's needed for easier adjustments in the view templates to display the maintenance messages
+```
+$ git clone https://github.com/jbbarth/redmine_base_deface.git
+```
+* change to your redmine root directory and run the following commands:
+```
+$ bundle install
+$ rake redmine:plugins:migrate RAILS_ENV=production
+```
+* Restart redmine
+
+
 License
 -------
 

--- a/app/overrides/account/login.rb
+++ b/app/overrides/account/login.rb
@@ -1,0 +1,5 @@
+Deface::Override.new :virtual_path  => 'account/login',
+                     :name          => 'add-maintenance-message-to-login',
+                     :original      => '1cfeb1658c55f2cd95207aa480c88fc7db3bb37e',
+                     :insert_top    => 'table',
+                     :partial       => 'maintenance/maintenance_login'

--- a/app/overrides/layouts/base.rb
+++ b/app/overrides/layouts/base.rb
@@ -1,0 +1,5 @@
+Deface::Override.new :virtual_path  => 'layouts/base',
+                     :name          => 'add-maintenance-message-to-bodytop',
+                     :original      => '02a2d374dd9b49b0d87fbb14252d3858726be83a',
+                     :insert_top    => 'body',
+                     :partial       => 'maintenance/maintenance_body'

--- a/app/views/maintenance/_maintenance_body.html.erb
+++ b/app/views/maintenance/_maintenance_body.html.erb
@@ -4,7 +4,7 @@
   plugin_url = Setting.protocol + "://" + Setting.host_name + "/settings/plugin/redmine_maintenance_mode"
 %>
 <% if User.current.login? && (settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance) %>
-  <div id="maintenance_mode_banner"><%= l(:maintenance_mode_admin_message).html_safe % [ :pluginurl => plugin_url ] %></div>
+  <div id="maintenance_mode_banner"><%=raw l(:maintenance_mode_admin_message) % [ :pluginurl => plugin_url ] %></div>
 <% elsif User.current.login? && settings[:maintenance_scheduled] && settings.has_key?(:schedule_start) && Time.now < Time.parse(settings[:schedule_start]) %>
   <div id="maintenance_mode_banner"><%= settings[:scheduled_message_f] %></div>
 <% else settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance %>

--- a/app/views/maintenance/_maintenance_body.html.erb
+++ b/app/views/maintenance/_maintenance_body.html.erb
@@ -1,0 +1,12 @@
+<%
+  require 'maintenance_mode_functions'
+  settings = MaintenanceModeFunctions.get_maintenance_plugin_settings
+  plugin_url = Setting.protocol + "://" + Setting.host_name + "/settings/plugin/redmine_maintenance_mode"
+%>
+<% if User.current.login? && (settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance) %>
+  <div id="maintenance_mode_banner"><%= l(:maintenance_mode_admin_message).html_safe % [ :pluginurl => plugin_url ] %></div>
+<% elsif User.current.login? && settings[:maintenance_scheduled] && settings.has_key?(:schedule_start) && Time.now < Time.parse(settings[:schedule_start]) %>
+  <div id="maintenance_mode_banner"><%= settings[:scheduled_message_f] %></div>
+<% else settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance %>
+  <div id="maintenance_mode_banner"><%= settings[:maintenance_message_f] %></div>
+<% end %>

--- a/app/views/maintenance/_maintenance_body.html.erb
+++ b/app/views/maintenance/_maintenance_body.html.erb
@@ -7,6 +7,6 @@
   <div id="maintenance_mode_banner"><%=raw l(:maintenance_mode_admin_message) % [ :pluginurl => plugin_url ] %></div>
 <% elsif User.current.login? && settings[:maintenance_scheduled] && settings.has_key?(:schedule_start) && Time.now < Time.parse(settings[:schedule_start]) %>
   <div id="maintenance_mode_banner"><%= textilizable(settings[:scheduled_message_f]) %></div>
-<% else settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance %>
+<% elsif settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance %>
   <div id="maintenance_mode_banner"><%= textilizable(settings[:maintenance_message_f]) %></div>
 <% end %>

--- a/app/views/maintenance/_maintenance_body.html.erb
+++ b/app/views/maintenance/_maintenance_body.html.erb
@@ -6,7 +6,7 @@
 <% if User.current.login? && (settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance) %>
   <div id="maintenance_mode_banner"><%=raw l(:maintenance_mode_admin_message) % [ :pluginurl => plugin_url ] %></div>
 <% elsif User.current.login? && settings[:maintenance_scheduled] && settings.has_key?(:schedule_start) && Time.now < Time.parse(settings[:schedule_start]) %>
-  <div id="maintenance_mode_banner"><%= settings[:scheduled_message_f] %></div>
+  <div id="maintenance_mode_banner"><%= textilizable(settings[:scheduled_message_f]) %></div>
 <% else settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance %>
-  <div id="maintenance_mode_banner"><%= settings[:maintenance_message_f] %></div>
+  <div id="maintenance_mode_banner"><%= textilizable(settings[:maintenance_message_f]) %></div>
 <% end %>

--- a/app/views/maintenance/_maintenance_login.html.erb
+++ b/app/views/maintenance/_maintenance_login.html.erb
@@ -4,6 +4,6 @@
 %>
 <% if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance %>
 <tr class="maintenance_message">
-  <td colspan="2"><%= settings[:maintenance_message_f] %></td>
+  <td colspan="2"><%= textilizable(settings[:maintenance_message_f]) %></td>
 </tr>
 <% end %>

--- a/app/views/maintenance/_maintenance_login.html.erb
+++ b/app/views/maintenance/_maintenance_login.html.erb
@@ -4,6 +4,9 @@
 %>
 <% if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance %>
 <tr class="maintenance_message">
-  <td colspan="2"><%= textilizable(settings[:maintenance_message_f]) %></td>
+  <td colspan="2">
+    <%= textilizable(settings[:maintenance_message_f]) %>
+    <p><%= l(:maintenance_mode_login_admin_only) %></p>
+  </td>
 </tr>
 <% end %>

--- a/app/views/maintenance/_maintenance_login.html.erb
+++ b/app/views/maintenance/_maintenance_login.html.erb
@@ -1,0 +1,9 @@
+<%
+  require 'maintenance_mode_functions'
+  settings = MaintenanceModeFunctions.get_maintenance_plugin_settings
+%>
+<% if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance %>
+<tr class="maintenance_message">
+  <td colspan="2"><%= settings[:maintenance_message_f] %></td>
+</tr>
+<% end %>

--- a/app/views/maintenance/_maintenance_styles.html.erb
+++ b/app/views/maintenance/_maintenance_styles.html.erb
@@ -1,0 +1,1 @@
+<%= stylesheet_link_tag 'maintenance_mode', :plugin => 'redmine_maintenance_mode' %>

--- a/assets/javascripts/banner.js
+++ b/assets/javascripts/banner.js
@@ -1,3 +1,0 @@
-$( document ).ready(function() {
-	$('#maintenance_mode_banner').prependTo('body');
-});

--- a/assets/stylesheets/maintenance_mode.css
+++ b/assets/stylesheets/maintenance_mode.css
@@ -11,6 +11,9 @@ div#maintenance_mode_banner {
     width: 100%;
     box-shadow: -10px 10px 20px -10px black;
 }
+div#maintenance_mode_banner p {
+    margin: 0;
+}
 /* push wrapper 35px down */
 #maintenance_mode_banner + #wrapper {
     padding-top: 35px;

--- a/assets/stylesheets/maintenance_mode.css
+++ b/assets/stylesheets/maintenance_mode.css
@@ -15,8 +15,16 @@ div#maintenance_mode_banner {
 #maintenance_mode_banner + #wrapper {
     padding-top: 35px;
 }
+#maintenance_mode_banner + #wrapper #top-menu {
+    padding-top: 10px;
+}
 
 #settings_maintenance.active,
 #settings_maintenance_schedule.active {
 	background-color: #ffd;
+}
+
+#login-form .maintenance_message {
+    background-color: yellow;
+    font-weight: bold;
 }

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -11,3 +11,4 @@ de:
   maintenance_mode_schedule_message_variables: Erlaubte Variablen
   maintenance_mode_schedule_time_label: Zeitraum der Wartungsarbeiten
   maintenance_mode_server_timezone_hint: "Zeitangaben richten sich nach der Zeitzone des Servers: %{timezone}"
+  maintenance_mode_login_admin_only: Anmeldung derzeit nur für Administratoren möglich!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,3 +11,4 @@ en:
   maintenance_mode_schedule_message_variables: Valid variables
   maintenance_mode_schedule_time_label: Maintenance period
   maintenance_mode_server_timezone_hint: "Time and date are evaluated using the server's timezone settings: %{timezone}"
+  maintenance_mode_login_admin_only: Login is currently limited to administrators only!

--- a/init.rb
+++ b/init.rb
@@ -13,14 +13,15 @@ Redmine::Plugin.register :redmine_maintenance_mode do
   author_url 'https://github.com/tofi86'
   
   requires_redmine :version_or_higher => '2.4.0'
+  requires_redmine_plugin :redmine_base_deface, :version_or_higher => '0.0.1'
   
   settings :default => {
     'maintenance_active' => false,
     'maintenance_message' => '',
     'maintenance_schedule' => false,
     'schedule_message' => '',
-    'schedule_start' => '2014-07-14 14:00',
-    'schedule_end' => '2014-07-14 15:00'
+    'schedule_start' => '2015-01-31 14:00',
+    'schedule_end' => '2015-01-31 15:00'
   }, :partial => 'redmine_maintenance_mode_settings'
 end
 

--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_maintenance_mode do
   name 'Redmine Maintenance Mode'
   author 'Tobias Fischer'
   description 'This is a plugin to schedule and announce maintenance downtimes as well as disable user access to redmine during maintenance times.'
-  version '1.1.0'
+  version '2.0.0'
   url 'https://github.com/tofi86/redmine_maintenance_mode'
   author_url 'https://github.com/tofi86'
   
@@ -20,8 +20,8 @@ Redmine::Plugin.register :redmine_maintenance_mode do
     'maintenance_message' => '',
     'maintenance_schedule' => false,
     'schedule_message' => '',
-    'schedule_start' => '2015-01-31 14:00',
-    'schedule_end' => '2015-01-31 15:00'
+    'schedule_start' => '2015-02-07 14:00',
+    'schedule_end' => '2015-02-07 15:00'
   }, :partial => 'redmine_maintenance_mode_settings'
 end
 

--- a/lib/maintenance_mode.rb
+++ b/lib/maintenance_mode.rb
@@ -14,9 +14,9 @@ module MaintenanceMode
         # only activate maintenance message if maintenance mode is activated or if we're in the middle of a scheduled maintenance 
         if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance
           # and only activate it for non-admin users
-          unless User.current.admin? || !User.current.logged?
-            logout_user
-            require_login
+          unless User.current.admin?
+            logout_user if User.current.logged?
+            require_login unless params[:controller] == "account" && params[:action] == "login"
             return false
           end
         end

--- a/lib/maintenance_mode_hooks.rb
+++ b/lib/maintenance_mode_hooks.rb
@@ -8,44 +8,8 @@ class MaintenanceModeHook < Redmine::Hook::ViewListener
         
     if settings[:maintenance_active] || settings[:maintenance_scheduled] || MaintenanceModeFunctions.is_now_scheduled_maintenance
       tags = stylesheet_link_tag 'maintenance_mode', :plugin => 'redmine_maintenance_mode'
-      tags += javascript_include_tag 'banner.js', :plugin => 'redmine_maintenance_mode'
       return tags
     end
-  end
-  
-  
-  # put admin message at the body_bottom as there is no body_top (#17454)
-  # a javascript function will then bring it up to the top
-  def view_layouts_base_body_bottom(context = {})
-        
-    # read plugin settings
-    settings = MaintenanceModeFunctions.get_maintenance_plugin_settings
-        
-    # only show banner for logged in users
-    if User.current.login?
-          
-      # if maintenance mode is activated or if we are in the middle of a scheduled maintenance
-      if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance
-        plugin_url = Setting.protocol + "://" + Setting.host_name + "/settings/plugin/redmine_maintenance_mode"
-        div_banner l(:maintenance_mode_admin_message) % [ :pluginurl => plugin_url ]
-          
-        # if maintenance is scheduled and current time is before the scheduled maintenance start time
-      elsif settings[:maintenance_scheduled] && settings.has_key?(:schedule_start) && Time.now < Time.parse(settings[:schedule_start])
-        div_banner settings[:scheduled_message_f]
-      end
-     
-    else
-      # show banner for logged out users - but only if we are in the middle of a maintenance period
-      if settings[:maintenance_active] || MaintenanceModeFunctions.is_now_scheduled_maintenance
-        div_banner settings[:maintenance_message_f]
-      end
-    end
-  end
-  
-  
-  # html code for the banner notification with custom message
-  def div_banner(message)
-    "<div id=\"maintenance_mode_banner\">" + message + "</div>"
   end
   
 end


### PR DESCRIPTION
This refactoring uses the ["Redmine base deface"](https://github.com/jbbarth/redmine_base_deface) plugin (the ["deface"](https://github.com/spree/deface) gem) for adding the maintenance messages to body_top and login form.

This is an advantage, as it doesn't involve overriding the original views, but instead has a nice syntax to "hack stuff into the original views"...

* Fixes #6 